### PR TITLE
allocationOpt: add gas cost consideration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 GraphQLClient = "09d831e3-9c21-47a9-bfd8-076871817219"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 

--- a/src/AllocationOpt.jl
+++ b/src/AllocationOpt.jl
@@ -1,4 +1,6 @@
 module AllocationOpt
+using Distributed
+export allocation_optimization
 
 export optimize_indexer_to_csv!
 
@@ -8,6 +10,7 @@ using DataFrames
 include("exceptions.jl")
 include("graphrepository.jl")
 include("data.jl")
+include("gascost.jl")
 include("optimize.jl")
 
 function optimize_indexer_to_csv!(;
@@ -26,4 +29,42 @@ function optimize_indexer_to_csv!(;
     return CSV.write(csv_write_path, df)
 end
 
+function filter_subgraphs(repo::Repository, allocList::Dict{String, Float64}, threshold::Float64)
+  return Repository(
+    repo.indexers, 
+    filter(x -> x.id in keys(allocList) && allocList[x.id] > threshold, repo.subgraphs)
+  )
+end
+
+function allocation_optimization(optimizeID::String, repository::Repository, gasBaseFee::Float64)
+  # initial run
+  allocList::Dict{String, Float64} = optimize(optimizeID, repository, nothing, nothing)[1]
+  println("given: \nrepository: $(repository)\nallocList: $(allocList)\ngasBaseFee: $(gasBaseFee)")
+  println("initial run - $(estimated_profit(repository, allocList, gasBaseFee))")
+
+  # preset parameters 
+  allocation_min_thresholds::Vector{Float64} = [0, gasBaseFee, gasBaseFee*3, gasBaseFee*10, gasBaseFee*50]
+  println("preset parameters - $(allocation_min_thresholds)")
+
+  # spawn jobs
+  for threshold in allocation_min_thresholds
+    filtered_repo = filter_subgraphs(repository, allocList, threshold)
+    println("gas base fee - $(threshold)")
+    if length(filtered_repo.subgraphs) > 0
+      plan = @spawn optimize(
+        optimizeID, 
+        filtered_repo, 
+        nothing, nothing)
+      result = fetch(plan)[1]
+      profit = estimated_profit(filtered_repo, result, gasBaseFee)
+      println("result: $(result) \nprofit: $(profit) \n")
+
+       # keep track of the most profitable allocation 
+      if profit >= estimated_profit(repository, allocList, gasBaseFee)
+        allocList = result
+      end
+    end
+  end
+  return allocList
+end
 end

--- a/src/data.jl
+++ b/src/data.jl
@@ -16,13 +16,9 @@ function allocations(id::String, sgraph_ids::Vector{String}, repo::Repository)
     end
     alloc = zeros(length(sgraph_ids))
     for al in indexer_allocations
-        ix = nothing
-        try
-            ix = first(findall(x -> x == al.id, sgraph_ids))
-        catch err
-            if isa(err, BoundsError)
-                throw(UnknownSubgraphError(al.id))
-            end
+        ix = findfirst(x -> x == al.id, sgraph_ids)
+        if (isnothing(ix))
+            throw(UnknownSubgraphError(al.id))
         end
         alloc[ix] = al.amount
     end
@@ -37,8 +33,20 @@ function allocations(repo::Repository)
     return mat
 end
 
+function allocations(repo::Repository, subgID::String)
+    allocAmount = 0
+    for indexer in repo.indexers
+        allocAmount += first(filter(alloc -> alloc.id == subgID, first(filter(x -> x.id == indexer.id, repo.indexers)).allocations)).amount
+    end
+    return allocAmount
+end
+
 function signals(repo::Repository)
     return map(x -> x.signal, repo.subgraphs)
+end
+
+function signals(repo::Repository, subgID::String)
+    return repo.subgraphs[findfirst(x -> x.id == subgID, repo.subgraphs)].signal
 end
 
 function stakes(repo::Repository)

--- a/src/gascost.jl
+++ b/src/gascost.jl
@@ -1,0 +1,25 @@
+export calculate_gas_fee, sum_gas_fee, estimated_profit
+
+function calculate_gas_fee(allocs::Dict{String, Float64}, txGas)
+    sum(map(x -> x > 0 ? txGas : 0, values(allocs)))
+end
+
+function sum_gas_fee(allocs::Dict{String, Float64}, txGas)
+    # open + close + claim
+    calculate_gas_fee(allocs, txGas) + calculate_gas_fee(allocs, txGas) + calculate_gas_fee(allocs, 0.3 * txGas)
+end
+
+function estimated_profit(repo::Repository, allocs::Dict{String, Float64}, txGas)
+    repository = Repository(repo.indexers, filter(x -> x.id in keys(allocs) ,repo.subgraphs))
+    rewards(repository, allocs) - sum_gas_fee(allocs, txGas)
+end
+
+function rewards(repo::Repository, allocs::Dict{String, Float64})
+    total = 0
+    for (id, amount) in allocs
+        total += signals(repo, id) * amount / (allocations(repo, id) + amount)
+    end
+    total
+end
+
+#TODO: add query to get real time gas rates for each tx -> this can be connected to indexer making gas estimations

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -38,7 +38,5 @@ function optimize(optimize_id::String, repository::Repository, whitelist, blackl
     sgraph_ids = map(x -> x.id, filtered_repo.subgraphs)
     alloc = Dict(sgraph_ids .=> ω)
 
-    # TODO: Hope's gas algorithm
-
     return alloc, filtered_repo
 end

--- a/test/allocationopt-test.jl
+++ b/test/allocationopt-test.jl
@@ -1,0 +1,19 @@
+@testset "AllocationOpt" begin
+
+  gas_fee = 0.3
+  repository = Repository(
+    [
+        Indexer(
+            "0x000", 5.0, 0.0, [Allocation("0x010", 2.5), Allocation("0x011", 2.5)]
+        ),
+        Indexer(
+            "0x001", 10.0, 0.0, [Allocation("0x010", 2.0), Allocation("0x011", 8.0)]
+        ),
+    ],
+    [Subgraph("0x011", 10.0), Subgraph("0x010", 5.0)],
+  )
+
+  allocations = allocation_optimization("0x000", repository, gas_fee)
+
+  @test allocations["0x011"] ≈ 5.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using Test
     include("graphrepository-test.jl")
     include("data-test.jl")
     include("optimize-test.jl")
+    include("allocationopt-test.jl")
 end


### PR DESCRIPTION
Simple evaluation of profit based on (indexing rewards - gas * number of allocations opened)

Next steps 
- Make allocation selection smarter. Currently after the initial optimization result only based on allocation amount. This could be improved by adding query fee or signal params
- Scale to accurate network parameters (preferred allocation lifetime, GRT and gas units) 
- command output / post requests 